### PR TITLE
Local sandbox fallback when DAYTONA_API_KEY missing

### DIFF
--- a/backend/sandbox/README.md
+++ b/backend/sandbox/README.md
@@ -11,6 +11,14 @@ The sandbox provides a complete containerized Linux environment with:
 - Full file system access
 - Full sudo access
 
+## Local Sandbox Fallback
+
+If the `DAYTONA_API_KEY` environment variable is not set, the backend will
+automatically start the sandbox defined in `docker/docker-compose.yml` using
+`docker compose`.  A lightweight object with the same interface as
+`daytona_sdk.Sandbox` is returned so existing tools continue to work when
+running locally.
+
 ## Customizing the Sandbox
 
 You can modify the sandbox environment for development or to add new capabilities:

--- a/backend/sandbox/sandbox.py
+++ b/backend/sandbox/sandbox.py
@@ -1,3 +1,8 @@
+import os
+import subprocess
+import shlex
+from pathlib import Path
+
 from daytona_sdk import Daytona, DaytonaConfig, CreateSandboxParams, Sandbox, SessionExecuteRequest
 from daytona_api_client.models.workspace_state import WorkspaceState
 from dotenv import load_dotenv
@@ -7,36 +12,252 @@ from utils.config import Configuration
 
 load_dotenv()
 
-logger.debug("Initializing Daytona sandbox configuration")
-daytona_config = DaytonaConfig(
-    api_key=config.DAYTONA_API_KEY,
-    server_url=config.DAYTONA_SERVER_URL,
-    target=config.DAYTONA_TARGET
-)
+# Determine if we should use Daytona or fall back to a local Docker sandbox
+_daytona_api_key = os.getenv("DAYTONA_API_KEY", "").strip()
+_use_daytona = bool(_daytona_api_key)
 
-if daytona_config.api_key:
-    logger.debug("Daytona API key configured successfully")
+if _use_daytona:
+    logger.debug("Initializing Daytona sandbox configuration")
+    daytona_config = DaytonaConfig(
+        api_key=config.DAYTONA_API_KEY,
+        server_url=config.DAYTONA_SERVER_URL,
+        target=config.DAYTONA_TARGET
+    )
+
+    if daytona_config.api_key:
+        logger.debug("Daytona API key configured successfully")
+    else:
+        logger.warning("No Daytona API key found in environment variables")
+
+    if daytona_config.server_url:
+        logger.debug(f"Daytona server URL set to: {daytona_config.server_url}")
+    else:
+        logger.warning("No Daytona server URL found in environment variables")
+
+    if daytona_config.target:
+        logger.debug(f"Daytona target set to: {daytona_config.target}")
+    else:
+        logger.warning("No Daytona target found in environment variables")
+
+    daytona = Daytona(daytona_config)
+    logger.debug("Daytona client initialized")
 else:
-    logger.warning("No Daytona API key found in environment variables")
+    daytona_config = None
+    daytona = None
+    logger.warning(
+        "DAYTONA_API_KEY not provided - using local docker-compose sandbox"
+    )
 
-if daytona_config.server_url:
-    logger.debug(f"Daytona server URL set to: {daytona_config.server_url}")
-else:
-    logger.warning("No Daytona server URL found in environment variables")
+    _compose_file = Path(__file__).parent / "docker" / "docker-compose.yml"
+    _local_sandbox = None
 
-if daytona_config.target:
-    logger.debug(f"Daytona target set to: {daytona_config.target}")
-else:
-    logger.warning("No Daytona target found in environment variables")
+    class LocalProcess:
+        """Minimal process management using docker exec and tmux."""
 
-daytona = Daytona(daytona_config)
-logger.debug("Daytona client initialized")
+        def __init__(self, container_id: str):
+            self.container_id = container_id
+
+        def exec(self, command: str, timeout: int = 60):
+            result = subprocess.run(
+                [
+                    "docker",
+                    "exec",
+                    self.container_id,
+                    "bash",
+                    "-lc",
+                    command,
+                ],
+                capture_output=True,
+                text=True,
+                timeout=timeout,
+            )
+            return type(
+                "ExecResult",
+                (),
+                {
+                    "exit_code": result.returncode,
+                    "result": result.stdout + result.stderr,
+                },
+            )()
+
+        def create_session(self, session_id: str):
+            subprocess.run(
+                [
+                    "docker",
+                    "exec",
+                    self.container_id,
+                    "tmux",
+                    "new-session",
+                    "-d",
+                    "-s",
+                    session_id,
+                ],
+                check=False,
+            )
+
+        def delete_session(self, session_id: str):
+            subprocess.run(
+                [
+                    "docker",
+                    "exec",
+                    self.container_id,
+                    "tmux",
+                    "kill-session",
+                    "-t",
+                    session_id,
+                ],
+                check=False,
+            )
+
+        def execute_session_command(self, session_id: str, req: SessionExecuteRequest, var_async: bool = True, **_):
+            cmd = req.command if hasattr(req, "command") else str(req)
+            subprocess.run(
+                [
+                    "docker",
+                    "exec",
+                    self.container_id,
+                    "tmux",
+                    "send-keys",
+                    "-t",
+                    session_id,
+                    cmd,
+                    "Enter",
+                ],
+                check=False,
+            )
+            return type(
+                "CmdResult",
+                (),
+                {"cmd_id": cmd, "exit_code": 0},
+            )()
+
+        def get_session_command_logs(self, session_id: str, command_id: str = None):
+            result = subprocess.run(
+                [
+                    "docker",
+                    "exec",
+                    self.container_id,
+                    "tmux",
+                    "capture-pane",
+                    "-t",
+                    session_id,
+                    "-p",
+                    "-S",
+                    "-",
+                    "-E",
+                    "-",
+                ],
+                capture_output=True,
+                text=True,
+            )
+            return result.stdout
+
+    class LocalFS:
+        """Minimal FS wrapper using docker exec."""
+
+        def __init__(self, container_id: str):
+            self.container_id = container_id
+
+        def create_folder(self, path: str, permissions: str = "755"):
+            subprocess.run(
+                [
+                    "docker",
+                    "exec",
+                    self.container_id,
+                    "mkdir",
+                    "-p",
+                    path,
+                ],
+                check=False,
+            )
+            subprocess.run(
+                [
+                    "docker",
+                    "exec",
+                    self.container_id,
+                    "chmod",
+                    permissions,
+                    path,
+                ],
+                check=False,
+            )
+
+        def upload_file(self, path: str, data: bytes):
+            subprocess.run(
+                [
+                    "docker",
+                    "exec",
+                    "-i",
+                    self.container_id,
+                    "bash",
+                    "-c",
+                    f"cat > {shlex.quote(path)}",
+                ],
+                input=data,
+                text=False,
+            )
+
+        def download_file(self, path: str):
+            result = subprocess.run(
+                ["docker", "exec", self.container_id, "cat", path],
+                capture_output=True,
+            )
+            return result.stdout
+
+        def delete_file(self, path: str):
+            subprocess.run(
+                ["docker", "exec", self.container_id, "rm", "-f", path],
+                check=False,
+            )
+
+        def set_file_permissions(self, path: str, permissions: str):
+            subprocess.run(
+                ["docker", "exec", self.container_id, "chmod", permissions, path],
+                check=False,
+            )
+
+    class LocalSandbox:
+        def __init__(self, container_id: str):
+            self.id = container_id
+            self.process = LocalProcess(container_id)
+            self.fs = LocalFS(container_id)
+
+        def get_preview_link(self, port: int):
+            return f"http://localhost:{port}"
+
+    def _ensure_local_sandbox() -> LocalSandbox:
+        global _local_sandbox
+        if _local_sandbox is None:
+            subprocess.run(
+                ["docker", "compose", "-f", str(_compose_file), "up", "-d"],
+                check=True,
+            )
+            container_id = (
+                subprocess.check_output(
+                    [
+                        "docker",
+                        "compose",
+                        "-f",
+                        str(_compose_file),
+                        "ps",
+                        "-q",
+                        "kortix-suna",
+                    ]
+                )
+                .decode()
+                .strip()
+            )
+            _local_sandbox = LocalSandbox(container_id or "local-sandbox")
+        return _local_sandbox
 
 async def get_or_start_sandbox(sandbox_id: str):
     """Retrieve a sandbox by ID, check its state, and start it if needed."""
-    
+
     logger.info(f"Getting or starting sandbox with ID: {sandbox_id}")
-    
+
+    if not _use_daytona:
+        return _ensure_local_sandbox()
+
     try:
         sandbox = daytona.get_current_sandbox(sandbox_id)
         
@@ -66,15 +287,21 @@ async def get_or_start_sandbox(sandbox_id: str):
 def start_supervisord_session(sandbox: Sandbox):
     """Start supervisord in a session."""
     session_id = "supervisord-session"
+    if not _use_daytona:
+        # The local container already runs supervisord via its entrypoint
+        return
     try:
         logger.info(f"Creating session {session_id} for supervisord")
         sandbox.process.create_session(session_id)
-        
+
         # Execute supervisord command
-        sandbox.process.execute_session_command(session_id, SessionExecuteRequest(
-            command="exec /usr/bin/supervisord -n -c /etc/supervisor/conf.d/supervisord.conf",
-            var_async=True
-        ))
+        sandbox.process.execute_session_command(
+            session_id,
+            SessionExecuteRequest(
+                command="exec /usr/bin/supervisord -n -c /etc/supervisor/conf.d/supervisord.conf",
+                var_async=True,
+            ),
+        )
         logger.info(f"Supervisord started in session {session_id}")
     except Exception as e:
         logger.error(f"Error starting supervisord session: {str(e)}")
@@ -82,7 +309,10 @@ def start_supervisord_session(sandbox: Sandbox):
 
 def create_sandbox(password: str, project_id: str = None):
     """Create a new sandbox with all required services configured and running."""
-    
+
+    if not _use_daytona:
+        return _ensure_local_sandbox()
+
     logger.debug("Creating new Daytona sandbox environment")
     logger.debug("Configuring sandbox with browser-use image and environment variables")
     
@@ -128,14 +358,20 @@ def create_sandbox(password: str, project_id: str = None):
 async def delete_sandbox(sandbox_id: str):
     """Delete a sandbox by its ID."""
     logger.info(f"Deleting sandbox with ID: {sandbox_id}")
-    
+
+    if not _use_daytona:
+        subprocess.run(["docker", "compose", "-f", str(_compose_file), "down"], check=False)
+        globals()["_local_sandbox"] = None
+        logger.info("Local sandbox stopped")
+        return True
+
     try:
         # Get the sandbox
         sandbox = daytona.get_current_sandbox(sandbox_id)
-        
+
         # Delete the sandbox
         daytona.remove(sandbox)
-        
+
         logger.info(f"Successfully deleted sandbox {sandbox_id}")
         return True
     except Exception as e:


### PR DESCRIPTION
## Summary
- start sandbox locally via docker-compose when DAYTONA_API_KEY is absent
- add lightweight `LocalSandbox` implementation for compatibility
- document the fallback behaviour in sandbox README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_68401a5c0904832f8df086a7e41ffe96